### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
       "{workspaceRoot}/.github/workflows/*.yml"
     ]
   },
-  "nxCloudId": "691ea1d76ba88c7e9e1887cb",
+  "nxCloudId": "694d0ca15b7251a312a6f0e0",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",
@@ -42,7 +42,9 @@
     }
   },
   "release": {
-    "projects": ["tag:publishable"],
+    "projects": [
+      "tag:publishable"
+    ],
     "versionPlans": true
   }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/694d0c8b5b7251a312a6f0da/workspaces/694d0ca15b7251a312a6f0e0

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.