### PR TITLE
feat(desktop): add settings page with Convex-backed persistence

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -4,12 +4,12 @@ import IntroVideo from './IntroVideo'
 import TitleScreen from './TitleScreen'
 import AuthGate from './AuthGate'
 import MusicPlayer from './MusicPlayer'
+import { SettingsProvider } from './contexts/SettingsContext'
 
 type Screen = 'disclaimer' | 'intro' | 'title' | 'game'
 
 function App(): JSX.Element {
   const [screen, setScreen] = useState<Screen>('disclaimer')
-  const showMusic = screen === 'title' || screen === 'game'
 
   const goTo = (next: Screen) => {
     setScreen(next)
@@ -24,10 +24,17 @@ function App(): JSX.Element {
         <IntroVideo onComplete={() => goTo('title')} />
       )}
       {screen === 'title' && (
-        <TitleScreen onStart={() => goTo('game')} />
+        <>
+          <TitleScreen onStart={() => goTo('game')} />
+          <MusicPlayer />
+        </>
       )}
-      {screen === 'game' && <AuthGate />}
-      {showMusic && <MusicPlayer />}
+      {screen === 'game' && (
+        <SettingsProvider>
+          <AuthGate />
+          <MusicPlayer />
+        </SettingsProvider>
+      )}
     </>
   )
 }

--- a/apps/desktop/src/MusicPlayer.tsx
+++ b/apps/desktop/src/MusicPlayer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { Howl } from 'howler'
+import { useOptionalSettings } from './contexts/SettingsContext'
 
 interface Song {
   id: string
@@ -22,6 +23,10 @@ function shuffle<T>(arr: T[]): T[] {
 }
 
 function MusicPlayer(): JSX.Element | null {
+  const settingsCtx = useOptionalSettings()
+  const musicVolume = settingsCtx?.settings.musicVolume ?? 0.5
+  const musicEnabled = settingsCtx?.settings.musicEnabled ?? true
+
   const howlRef = useRef<Howl | null>(null)
   const queueRef = useRef<Song[]>([])
   const playlistRef = useRef<Song[]>([])
@@ -37,7 +42,7 @@ function MusicPlayer(): JSX.Element | null {
     const howl = new Howl({
       src: [song.file],
       html5: true,
-      volume: 0.5,
+      volume: musicVolume,
       onend: () => {
         let next = queueRef.current.slice(1)
         if (next.length === 0) {
@@ -95,6 +100,25 @@ function MusicPlayer(): JSX.Element | null {
       clearTimeout(hideTimer)
     }
   }, [current])
+
+  // Sync volume from settings
+  useEffect(() => {
+    if (howlRef.current) {
+      howlRef.current.volume(musicVolume)
+    }
+  }, [musicVolume])
+
+  // Pause/resume based on musicEnabled
+  useEffect(() => {
+    if (!howlRef.current) return
+    if (musicEnabled) {
+      if (!howlRef.current.playing()) {
+        howlRef.current.play()
+      }
+    } else {
+      howlRef.current.pause()
+    }
+  }, [musicEnabled])
 
   if (!toast) return null
 

--- a/apps/desktop/src/contexts/SettingsContext.tsx
+++ b/apps/desktop/src/contexts/SettingsContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react'
+import { useSettings } from '../hooks/useSettings'
+
+export type { UserSettings } from '../hooks/useSettings'
+
+type SettingsContextValue = ReturnType<typeof useSettings>
+
+const SettingsContext = createContext<SettingsContextValue | null>(null)
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const value = useSettings()
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}
+
+export function useSettingsContext(): SettingsContextValue {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) {
+    throw new Error('useSettingsContext must be used within SettingsProvider')
+  }
+  return ctx
+}
+
+export function useOptionalSettings(): SettingsContextValue | null {
+  return useContext(SettingsContext)
+}

--- a/apps/desktop/src/hooks/useSettings.ts
+++ b/apps/desktop/src/hooks/useSettings.ts
@@ -1,0 +1,69 @@
+import { useQuery, useMutation } from 'convex/react'
+import { api } from '@convex/_generated/api'
+import { useState, useCallback, useRef } from 'react'
+
+export interface UserSettings {
+  musicVolume: number
+  sfxVolume: number
+  musicEnabled: boolean
+  animationSpeed: 'normal' | 'fast' | 'off'
+  cardArtQuality: 'low' | 'medium' | 'high'
+  reducedMotion: boolean
+  autoPassPriority: boolean
+  confirmBeforeAttacking: boolean
+  showCardTooltips: boolean
+}
+
+const DEFAULT_SETTINGS: UserSettings = {
+  musicVolume: 0.5,
+  sfxVolume: 0.5,
+  musicEnabled: true,
+  animationSpeed: 'normal',
+  cardArtQuality: 'high',
+  reducedMotion: false,
+  autoPassPriority: false,
+  confirmBeforeAttacking: true,
+  showCardTooltips: true,
+}
+
+type SettingsKey = keyof UserSettings
+
+export function useSettings() {
+  const remoteSettings = useQuery(api.userSettings.get)
+  const updateMutation = useMutation(api.userSettings.update)
+  const [localOverrides, setLocalOverrides] = useState<Partial<UserSettings>>({})
+  const pendingRef = useRef<Partial<UserSettings>>({})
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const settings: UserSettings = {
+    ...DEFAULT_SETTINGS,
+    ...(remoteSettings ?? {}),
+    ...localOverrides,
+  }
+
+  const updateSetting = useCallback(
+    <K extends SettingsKey>(key: K, value: UserSettings[K]) => {
+      setLocalOverrides((prev) => ({ ...prev, [key]: value }))
+      pendingRef.current = { ...pendingRef.current, [key]: value }
+
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+
+      timerRef.current = setTimeout(() => {
+        const changes = pendingRef.current
+        pendingRef.current = {}
+        updateMutation(changes).then(() => {
+          setLocalOverrides({})
+        })
+      }, 500)
+    },
+    [updateMutation]
+  )
+
+  return {
+    settings,
+    updateSetting,
+    isLoading: remoteSettings === undefined,
+  }
+}

--- a/apps/desktop/src/menu/MenuScreen.tsx
+++ b/apps/desktop/src/menu/MenuScreen.tsx
@@ -9,6 +9,7 @@ import RecentMatches from './RecentMatches'
 import Goals from './Goals'
 import CollectionPage from './CollectionPage'
 import DeckBuilderPage from './DeckBuilderPage'
+import SettingsPage from './SettingsPage'
 
 function MenuScreen(): JSX.Element {
   const [activeTab, setActiveTab] = useState<SidebarTab>('home')
@@ -24,7 +25,7 @@ function MenuScreen(): JSX.Element {
           {activeTab === 'collection' && <CollectionPage />}
           {activeTab === 'play' && <PlaceholderPage title="Play" />}
           {activeTab === 'friends' && <PlaceholderPage title="Friends" />}
-          {activeTab === 'settings' && <PlaceholderPage title="Settings" />}
+          {activeTab === 'settings' && <SettingsPage />}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/menu/SettingsPage.tsx
+++ b/apps/desktop/src/menu/SettingsPage.tsx
@@ -1,0 +1,376 @@
+import { useState } from 'react'
+import { useUser, useClerk } from '@clerk/clerk-react'
+import { theme } from './theme'
+import { useSettingsContext } from '../contexts/SettingsContext'
+import type { UserSettings } from '../hooks/useSettings'
+
+function SettingsPage(): JSX.Element {
+  const { settings, updateSetting, isLoading } = useSettingsContext()
+  const { user } = useUser()
+  const clerk = useClerk()
+  const [saved, setSaved] = useState(false)
+
+  const showSaved = () => {
+    setSaved(true)
+    setTimeout(() => setSaved(false), 2000)
+  }
+
+  const handleUpdate = <K extends keyof UserSettings>(key: K, value: UserSettings[K]) => {
+    updateSetting(key, value)
+    showSaved()
+  }
+
+  if (isLoading) {
+    return (
+      <div style={styles.container}>
+        <p style={{ color: theme.textMuted, fontSize: 14 }}>Loading settings...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <h2 style={styles.pageTitle}>Settings</h2>
+        <span
+          style={{
+            ...styles.savedBadge,
+            opacity: saved ? 1 : 0,
+            transform: saved ? 'translateY(0)' : 'translateY(-4px)',
+          }}
+        >
+          Saved
+        </span>
+      </div>
+
+      <Section title="Audio">
+        <SliderRow
+          label="Music Volume"
+          value={settings.musicVolume}
+          onChange={(v) => handleUpdate('musicVolume', v)}
+        />
+        <SliderRow
+          label="Sound Effects"
+          value={settings.sfxVolume}
+          onChange={(v) => handleUpdate('sfxVolume', v)}
+        />
+        <ToggleRow
+          label="Music Enabled"
+          value={settings.musicEnabled}
+          onChange={(v) => handleUpdate('musicEnabled', v)}
+        />
+      </Section>
+
+      <Section title="Display">
+        <SelectRow
+          label="Animation Speed"
+          value={settings.animationSpeed}
+          options={[
+            { value: 'normal', label: 'Normal' },
+            { value: 'fast', label: 'Fast' },
+            { value: 'off', label: 'Off' },
+          ]}
+          onChange={(v) => handleUpdate('animationSpeed', v as UserSettings['animationSpeed'])}
+        />
+        <SelectRow
+          label="Card Art Quality"
+          value={settings.cardArtQuality}
+          options={[
+            { value: 'low', label: 'Low' },
+            { value: 'medium', label: 'Medium' },
+            { value: 'high', label: 'High' },
+          ]}
+          onChange={(v) => handleUpdate('cardArtQuality', v as UserSettings['cardArtQuality'])}
+        />
+        <ToggleRow
+          label="Reduced Motion"
+          value={settings.reducedMotion}
+          onChange={(v) => handleUpdate('reducedMotion', v)}
+        />
+      </Section>
+
+      <Section title="Gameplay">
+        <ToggleRow
+          label="Auto-pass Priority"
+          value={settings.autoPassPriority}
+          onChange={(v) => handleUpdate('autoPassPriority', v)}
+        />
+        <ToggleRow
+          label="Confirm Before Attacking"
+          value={settings.confirmBeforeAttacking}
+          onChange={(v) => handleUpdate('confirmBeforeAttacking', v)}
+        />
+        <ToggleRow
+          label="Show Card Tooltips"
+          value={settings.showCardTooltips}
+          onChange={(v) => handleUpdate('showCardTooltips', v)}
+        />
+      </Section>
+
+      <Section title="Account">
+        {user && (
+          <div style={styles.accountRow}>
+            <img
+              src={user.imageUrl}
+              alt=""
+              style={styles.avatar}
+            />
+            <div>
+              <div style={styles.userName}>
+                {user.fullName ?? user.primaryEmailAddress?.emailAddress ?? 'User'}
+              </div>
+              <div style={styles.userEmail}>
+                {user.primaryEmailAddress?.emailAddress}
+              </div>
+            </div>
+          </div>
+        )}
+        <button
+          style={styles.signOutBtn}
+          onClick={() => clerk.signOut()}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = 'rgba(230, 57, 70, 0.3)'
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = 'rgba(230, 57, 70, 0.15)'
+          }}
+        >
+          Sign Out
+        </button>
+      </Section>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <div style={styles.section}>
+      <h3 style={styles.sectionTitle}>{title}</h3>
+      <div style={styles.sectionContent}>{children}</div>
+    </div>
+  )
+}
+
+function SliderRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: number
+  onChange: (v: number) => void
+}): JSX.Element {
+  return (
+    <div style={styles.row}>
+      <span style={styles.label}>{label}</span>
+      <div style={styles.sliderGroup}>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          style={styles.slider}
+        />
+        <span style={styles.sliderValue}>{Math.round(value * 100)}%</span>
+      </div>
+    </div>
+  )
+}
+
+function ToggleRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: boolean
+  onChange: (v: boolean) => void
+}): JSX.Element {
+  return (
+    <div style={styles.row}>
+      <span style={styles.label}>{label}</span>
+      <div
+        onClick={() => onChange(!value)}
+        style={{
+          ...styles.toggle,
+          background: value ? theme.accent : 'rgba(255, 255, 255, 0.1)',
+        }}
+      >
+        <div
+          style={{
+            ...styles.toggleKnob,
+            transform: value ? 'translateX(18px)' : 'translateX(0)',
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function SelectRow({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (v: string) => void
+}): JSX.Element {
+  return (
+    <div style={styles.row}>
+      <span style={styles.label}>{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={styles.select}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 20,
+    maxWidth: 640,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+  },
+  pageTitle: {
+    fontSize: 22,
+    fontWeight: 700,
+    color: theme.text,
+    margin: 0,
+  },
+  savedBadge: {
+    fontSize: 11,
+    fontWeight: 600,
+    color: theme.accentGreen,
+    transition: 'opacity 0.3s ease, transform 0.3s ease',
+  },
+  section: {
+    ...theme.glass,
+    padding: 20,
+  } as React.CSSProperties,
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: 700,
+    color: theme.accent,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '1px',
+    margin: '0 0 16px 0',
+  },
+  sectionContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 14,
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 16,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: 500,
+    color: theme.text,
+  },
+  sliderGroup: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+  },
+  slider: {
+    width: 140,
+    accentColor: theme.accent,
+    cursor: 'pointer',
+  },
+  sliderValue: {
+    fontSize: 12,
+    fontWeight: 600,
+    color: theme.textMuted,
+    width: 36,
+    textAlign: 'right' as const,
+  },
+  toggle: {
+    width: 40,
+    height: 22,
+    borderRadius: 11,
+    cursor: 'pointer',
+    position: 'relative' as const,
+    transition: 'background 0.2s ease',
+    flexShrink: 0,
+  },
+  toggleKnob: {
+    width: 18,
+    height: 18,
+    borderRadius: '50%',
+    background: '#fff',
+    position: 'absolute' as const,
+    top: 2,
+    left: 2,
+    transition: 'transform 0.2s ease',
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.3)',
+  },
+  select: {
+    fontSize: 13,
+    padding: '6px 10px',
+    borderRadius: 8,
+    border: `1px solid ${theme.borderLight}`,
+    background: theme.bgCardSolid,
+    color: theme.text,
+    cursor: 'pointer',
+    outline: 'none',
+  },
+  accountRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 4,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: '50%',
+    objectFit: 'cover' as const,
+  },
+  userName: {
+    fontSize: 14,
+    fontWeight: 600,
+    color: theme.text,
+  },
+  userEmail: {
+    fontSize: 12,
+    color: theme.textMuted,
+    marginTop: 2,
+  },
+  signOutBtn: {
+    fontSize: 13,
+    fontWeight: 600,
+    color: theme.accentRed,
+    background: 'rgba(230, 57, 70, 0.15)',
+    border: `1px solid rgba(230, 57, 70, 0.3)`,
+    borderRadius: 8,
+    padding: '8px 16px',
+    cursor: 'pointer',
+    transition: 'background 0.2s ease',
+    alignSelf: 'flex-start',
+  },
+}
+
+export default SettingsPage

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -7,8 +7,11 @@
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@convex/*": ["../web/convex/*"]
+    }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../web/convex/**/*"],
   "exclude": ["src-tauri"]
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         __dirname,
         'node_modules/convex/dist/esm/react-clerk/index.js'
       ),
+      '@convex': path.resolve(__dirname, '../web/convex'),
     },
   },
 

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as card_baseCard from "../card/baseCard.js";
 import type * as card_civilization from "../card/civilization.js";
 import type * as card_race from "../card/race.js";
 import type * as card_rarity from "../card/rarity.js";
+import type * as userSettings from "../userSettings.js";
 
 import type {
   ApiFromModules,
@@ -24,6 +25,7 @@ declare const fullApi: ApiFromModules<{
   "card/civilization": typeof card_civilization;
   "card/race": typeof card_race;
   "card/rarity": typeof card_rarity;
+  userSettings: typeof userSettings;
 }>;
 
 /**

--- a/apps/web/convex/_generated/dataModel.d.ts
+++ b/apps/web/convex/_generated/dataModel.d.ts
@@ -38,7 +38,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * Convex documents are uniquely identified by their `Id`, which is accessible
  * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
  *
- * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ * Documents can be loaded using `db.get(id)` in query and mutation functions.
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.

--- a/apps/web/convex/auth.config.ts
+++ b/apps/web/convex/auth.config.ts
@@ -3,11 +3,9 @@ import { AuthConfig } from "convex/server";
 export default {
   providers: [
     {
-      // Replace with your own Clerk Issuer URL from your "convex" JWT template
-      // or with `process.env.CLERK_FRONTEND_API_URL`
-      // and configure CLERK_FRONTEND_API_URL on the Convex Dashboard
+      // Clerk JWT issuer domain, configured on the Convex Dashboard
       // See https://docs.convex.dev/auth/clerk#configuring-dev-and-prod-instances
-      domain: process.env.CLERK_FRONTEND_API_URL!,
+      domain: process.env.CLERK_JWT_ISSUER_DOMAIN!,
       applicationID: "convex",
     },
   ],

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -18,4 +18,25 @@ export default defineSchema({
       })
     )
   ).index("by_name", ["name"]),
+
+  userSettings: defineTable({
+    userId: v.string(),
+    musicVolume: v.number(),
+    sfxVolume: v.number(),
+    musicEnabled: v.boolean(),
+    animationSpeed: v.union(
+      v.literal("normal"),
+      v.literal("fast"),
+      v.literal("off")
+    ),
+    cardArtQuality: v.union(
+      v.literal("low"),
+      v.literal("medium"),
+      v.literal("high")
+    ),
+    reducedMotion: v.boolean(),
+    autoPassPriority: v.boolean(),
+    confirmBeforeAttacking: v.boolean(),
+    showCardTooltips: v.boolean(),
+  }).index("by_userId", ["userId"]),
 });

--- a/apps/web/convex/userSettings.ts
+++ b/apps/web/convex/userSettings.ts
@@ -1,0 +1,77 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const DEFAULT_SETTINGS = {
+  musicVolume: 0.5,
+  sfxVolume: 0.5,
+  musicEnabled: true,
+  animationSpeed: "normal" as const,
+  cardArtQuality: "high" as const,
+  reducedMotion: false,
+  autoPassPriority: false,
+  confirmBeforeAttacking: true,
+  showCardTooltips: true,
+};
+
+export type UserSettings = typeof DEFAULT_SETTINGS;
+
+export const get = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return DEFAULT_SETTINGS;
+    }
+
+    const row = await ctx.db
+      .query("userSettings")
+      .withIndex("by_userId", (q) => q.eq("userId", identity.tokenIdentifier))
+      .unique();
+
+    if (!row) {
+      return DEFAULT_SETTINGS;
+    }
+
+    const { _id, _creationTime, userId, ...settings } = row;
+    return settings;
+  },
+});
+
+export const update = mutation({
+  args: {
+    musicVolume: v.optional(v.number()),
+    sfxVolume: v.optional(v.number()),
+    musicEnabled: v.optional(v.boolean()),
+    animationSpeed: v.optional(
+      v.union(v.literal("normal"), v.literal("fast"), v.literal("off"))
+    ),
+    cardArtQuality: v.optional(
+      v.union(v.literal("low"), v.literal("medium"), v.literal("high"))
+    ),
+    reducedMotion: v.optional(v.boolean()),
+    autoPassPriority: v.optional(v.boolean()),
+    confirmBeforeAttacking: v.optional(v.boolean()),
+    showCardTooltips: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Not authenticated");
+    }
+
+    const existing = await ctx.db
+      .query("userSettings")
+      .withIndex("by_userId", (q) => q.eq("userId", identity.tokenIdentifier))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, args);
+    } else {
+      await ctx.db.insert("userSettings", {
+        userId: identity.tokenIdentifier,
+        ...DEFAULT_SETTINGS,
+        ...args,
+      });
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- Add `userSettings` table to Convex schema with `get` query and `update` upsert mutation, defaulting to sensible values for unauthenticated users
- Create `useSettings` React hook with 500ms debounced auto-save, optimistic local overrides, and batched mutation calls
- Build `SettingsPage` component with four sections: Audio (volume sliders, music toggle), Display (animation speed, card quality, reduced motion), Gameplay (auto-pass, confirm attacks, tooltips), Account (user info + sign out)
- Wire `SettingsProvider` context into `App.tsx` so `MusicPlayer` reads volume/enabled from settings
- `MusicPlayer` now syncs volume in real-time and supports pause/resume via `musicEnabled` toggle
- Add `@convex` Vite alias + TypeScript paths so desktop app can import Convex API types from the web app

Closes #13

## Test plan
- [ ] `npx convex dev` deploys schema without errors
- [ ] Desktop app starts (`pnpm tauri dev`)
- [ ] Navigate to Settings tab — page renders with all four sections
- [ ] Adjust music volume slider — hear volume change in real time
- [ ] Toggle music off/on — music stops/resumes
- [ ] Refresh page — settings persist (loaded from Convex)
- [ ] Check Convex dashboard — `userSettings` row created for user
- [ ] Sign out button works (redirects to auth screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Settings menu: Audio, Display, Gameplay, and Account sections with sliders, toggles, and selectors
  * Settings persist to backend and load on startup
  * Music player responds live to volume and enable/disable settings
  * Account area shows user info and a Sign Out action

* **UX**
  * Music playback consistently available on title and game screens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->