### PR TITLE
fix(desktop): resolve Clerk signin black screen and reduce intro video volume

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -28,12 +28,7 @@ function App(): JSX.Element {
           <MusicPlayer />
         </>
       )}
-      {screen === 'game' && (
-        <>
-          <AuthGate />
-          <MusicPlayer />
-        </>
-      )}
+      {screen === 'game' && <AuthGate />}
     </>
   )
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -4,7 +4,6 @@ import IntroVideo from './IntroVideo'
 import TitleScreen from './TitleScreen'
 import AuthGate from './AuthGate'
 import MusicPlayer from './MusicPlayer'
-import { SettingsProvider } from './contexts/SettingsContext'
 
 type Screen = 'disclaimer' | 'intro' | 'title' | 'game'
 
@@ -30,10 +29,10 @@ function App(): JSX.Element {
         </>
       )}
       {screen === 'game' && (
-        <SettingsProvider>
+        <>
           <AuthGate />
           <MusicPlayer />
-        </SettingsProvider>
+        </>
       )}
     </>
   )

--- a/apps/desktop/src/AuthGate.tsx
+++ b/apps/desktop/src/AuthGate.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '@clerk/clerk-react'
 import AuthScreen from './AuthScreen'
 import MenuScreen from './menu/MenuScreen'
+import MusicPlayer from './MusicPlayer'
 import { SettingsProvider } from './contexts/SettingsContext'
 
 function AuthGate(): JSX.Element {
@@ -21,6 +22,7 @@ function AuthGate(): JSX.Element {
   return (
     <SettingsProvider>
       <MenuScreen />
+      <MusicPlayer />
     </SettingsProvider>
   )
 }

--- a/apps/desktop/src/AuthGate.tsx
+++ b/apps/desktop/src/AuthGate.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '@clerk/clerk-react'
 import AuthScreen from './AuthScreen'
 import MenuScreen from './menu/MenuScreen'
+import { SettingsProvider } from './contexts/SettingsContext'
 
 function AuthGate(): JSX.Element {
   const { isSignedIn, isLoaded } = useAuth()
@@ -17,7 +18,11 @@ function AuthGate(): JSX.Element {
     return <AuthScreen />
   }
 
-  return <MenuScreen />
+  return (
+    <SettingsProvider>
+      <MenuScreen />
+    </SettingsProvider>
+  )
 }
 
 const styles: Record<string, React.CSSProperties> = {

--- a/apps/desktop/src/AuthScreen.tsx
+++ b/apps/desktop/src/AuthScreen.tsx
@@ -4,6 +4,7 @@ function AuthScreen(): JSX.Element {
   return (
     <div style={styles.container}>
       <SignIn
+        routing="virtual"
         appearance={{
           variables: {
             colorPrimary: '#e0e0e0',

--- a/apps/desktop/src/IntroVideo.tsx
+++ b/apps/desktop/src/IntroVideo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 interface IntroVideoProps {
   onComplete: () => void
@@ -15,7 +15,7 @@ function IntroVideo({ onComplete }: IntroVideoProps): JSX.Element {
     return () => clearTimeout(timer)
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (videoRef.current) {
       videoRef.current.volume = 0.1
     }

--- a/apps/desktop/src/IntroVideo.tsx
+++ b/apps/desktop/src/IntroVideo.tsx
@@ -16,6 +16,12 @@ function IntroVideo({ onComplete }: IntroVideoProps): JSX.Element {
   }, [])
 
   useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.volume = 0.1
+    }
+  }, [])
+
+  useEffect(() => {
     const handleKey = () => onComplete()
     const handleClick = (e: MouseEvent) => {
       // Don't double-fire if they click the skip button


### PR DESCRIPTION
## Summary

Fixes [#21](https://github.com/vreddi/kaijudo/issues/21) — prevents Clerk SignIn from showing black screen on login flow, reduces intro video audio to 10%, and adds Clerk routing prop for Tauri desktop context.

### Root Cause

SettingsProvider was wrapping AuthGate at the app level, calling `useQuery(api.userSettings.get)` during initialization. When the user was unauthenticated, this Convex subscription would fail, crashing the entire SettingsProvider subtree and unmounting the freshly-rendered SignIn form.

### Changes

1. **Move SettingsProvider into AuthGate** — Now only wraps MenuScreen (signed-in branch), so Convex queries only subscribe after authentication.
2. **Set intro video volume to 0.1** — IntroVideo now explicitly sets `video.volume = 0.1` to reduce jarring audio.
3. **Add routing="virtual" to SignIn** — Clerk's routing prop ensures proper behavior in Tauri's custom URL environment.

## Test Plan

- [ ] Run desktop app (`pnpm --filter @kaijudo/desktop dev:frontend` for preview or full `tauri dev`)
- [ ] Accept disclaimer, watch intro (verify audio is at ~10% volume)
- [ ] Press Enter from title screen
- [ ] Verify Clerk SignIn form renders without black screen
- [ ] Complete sign-in successfully
- [ ] Verify MenuScreen appears after sign-in

## Files Changed

- `apps/desktop/src/App.tsx` — Removed SettingsProvider wrapper
- `apps/desktop/src/AuthGate.tsx` — Moved SettingsProvider into signed-in branch
- `apps/desktop/src/AuthScreen.tsx` — Added `routing="virtual"` to SignIn
- `apps/desktop/src/IntroVideo.tsx` — Set video volume to 0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Intro video volume adjusted to 10% for improved audio balance
  * Authentication screen routing configuration optimized

* **Refactor**
  * Restructured settings provider initialization flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->